### PR TITLE
Better message on unsupported CL implementations.

### DIFF
--- a/static-vectors.asd
+++ b/static-vectors.asd
@@ -24,7 +24,9 @@
                                 #+cmu       "impl-cmucl"
                                 #+ecl       "impl-ecl"
                                 #+lispworks "impl-lispworks"
-                                #+sbcl      "impl-sbcl")
+                                #+sbcl      "impl-sbcl"
+                                #-(or allegro ccl cmu ecl lispworks sbcl)
+                                  #.(error "static-vectors does not support this Common Lisp implementation!"))
                (:file "constructor" :depends-on ("pkgdcl" "constantp" "initialize" "impl"))
                (:file "cffi-type-translator" :depends-on ("pkgdcl" "impl"))))
 


### PR DESCRIPTION
Trying to load static-vectors on CLISP results in the following, confusing for a newbie, message:

[1]> (ql:quickload :woo)
To load "cffi-grovel":
  Load 1 ASDF system:
    cffi-grovel
; Loading "cffi-grovel"

To load "woo":
  Load 1 ASDF system:
    woo
; Loading "woo"

*** - Error while trying to load definition for system static-vectors from
      pathname
      /home/antonis/Documents/Projects/quicklisp/dists/quicklisp/software/static-vectors-1.6/static-vectors.asd:
      GETF: the property list (:DEPENDS-ON ("pkgdcl" "constantp" "initialize")
      :PATHNAME) has an odd length
The following restarts are available:
SKIP           :R1      skip (DEFSYSTEM STATIC-VECTORS DESCRIPTION ...)
RETRY          :R2      retry (DEFSYSTEM STATIC-VECTORS DESCRIPTION ...)
STOP           :R3      stop loading file /home/antonis/Documents/Projects/quicklisp/dists/quicklisp/software/static-vectors-1.6/static-vectors.asd
RETRY          :R4      Retry ASDF operation.
CLEAR-CONFIGURATION-AND-RETRY :R5 Retry ASDF operation after resetting the configuration.
ABORT          :R6      Give up on "woo"
ABORT          :R7      Abort main loop
Break 1 ASDF/USER[2]>

This is just a trivial PR adding a clear message for unsupported CL implemetations; feel free to reject it. :)