### PR TITLE
abcl: initial implementation

### DIFF
--- a/src/impl-abcl.lisp
+++ b/src/impl-abcl.lisp
@@ -1,0 +1,77 @@
+;;;; -*- Mode: Lisp; indent-tabs-mode: nil -*-
+;;;
+;;; --- Armed Bear CL implementation
+;;;
+
+(in-package :static-vectors)
+
+(declaim (inline fill-foreign-memory))
+(defun fill-foreign-memory (pointer length value)
+  (foreign-funcall "memset" :pointer pointer :int value size-t length :pointer)  
+  pointer)
+
+(declaim (inline replace-foreign-memory))
+(defun replace-foreign-memory (dst-ptr src-ptr length)
+  "Copy LENGTH octets from foreign memory area SRC-PTR to DST-PTR."
+  (foreign-funcall "memcpy" :pointer dst-ptr :pointer src-ptr size-t length :pointer)
+  dst-ptr)
+
+;;; HACK for now
+(defvar *static-vector-pointer*
+  (make-hash-table :weakness :value))
+
+(declaim (inline %allocate-static-vector))
+(defun %allocate-static-vector (length element-type)
+  (flet ((size-of (element-type)
+           ;; assume 8-bit bytes
+           1))
+    (let* ((bytes
+             (* length (size-of element-type)))
+           (heap-pointer
+             (jss:new "com.sun.jna.Memory" bytes))
+           (bytebuffer
+             (#"getByteBuffer" heap-pointer 0 bytes))
+           (static-vector
+             (ext:make-bytebuffer-byte-vector bytebuffer)))
+      (setf (gethash static-vector *static-vector-pointer*)
+            heap-pointer)
+      (values
+       static-vector
+       heap-pointer))))
+ 
+(declaim (inline static-vector-pointer))
+(defun static-vector-pointer (vector &key (offset 0))
+  "Return a foreign pointer to the beginning of VECTOR + OFFSET octets.
+VECTOR must be a vector created by MAKE-STATIC-VECTOR."
+  (check-type offset unsigned-byte)
+  ;;; FIXME collapse it
+  (let ((expected-type 'vector))  ;; FIXME tighten
+    (unless (typep vector expected-type)
+      (signal 'simple-type-error vector expected-type))
+    (let ((pointer (gethash vector *static-vector-pointer*)))
+      (unless pointer
+        (signal 'simple-error "vector ~a doesn't have an associated pointer to malloc()-ed memory" vector))
+      (cffi-sys:inc-pointer pointer offset))))
+
+(declaim (inline free-static-vector))
+(defun free-static-vector (vector)
+  "Free VECTOR, which must be a vector created by MAKE-STATIC-VECTOR."
+  (let ((pointer (gethash vector *static-vector-pointer*)))
+    (when pointer
+      (cffi-sys:foreign-free pointer)
+      (setf (gethash vector *static-vector-pointer*) nil))))
+  
+
+(defmacro with-static-vector ((var length &rest args
+                               &key (element-type '(unsigned-byte 8))
+                                 initial-contents initial-element)
+                              &body body)
+  "Bind PTR-VAR to a static vector of length LENGTH and execute BODY
+within its dynamic extent. The vector is freed upon exit."
+  (declare (ignore element-type initial-contents initial-element))
+  `(let ((,var nil))
+     (unwind-protect
+          (progn
+            (setf ,var (make-static-vector ,length ,@args))
+            (locally ,@body))
+       (when ,var (free-static-vector ,var)))))

--- a/static-vectors.asd
+++ b/static-vectors.asd
@@ -8,25 +8,26 @@
   :author "Stelian Ionescu <sionescu@cddr.org>"
   :licence "MIT"
   :version (:read-file-form "version.sexp")
-  :defsystem-depends-on (#+(or allegro clasp cmu ecl sbcl) :cffi-grovel)
+  :defsystem-depends-on (#+(or abcl allegro clasp cmu ecl sbcl) :cffi-grovel)
   :depends-on (:alexandria :cffi)
   :pathname "src/"
   :components ((:file "pkgdcl")
                (:file "constantp" :depends-on ("pkgdcl"))
                (:file "initialize" :depends-on ("pkgdcl" "constantp"))
-               #+(or allegro clasp cmu ecl)
+               #+(or abcl allegro clasp cmu ecl)
                (:cffi-grovel-file "ffi-types" :depends-on ("pkgdcl"))
                (:file "impl"
                       :depends-on ("pkgdcl" "constantp" "initialize"
-                                   #+(or allegro cmu ecl) "ffi-types")
-                      :pathname #+allegro   "impl-allegro"
+                                   #+(or abcl allegro cmu ecl) "ffi-types")
+                      :pathname #+abcl      "impl-abcl"
+                                #+allegro   "impl-allegro"
                                 #+ccl       "impl-clozure"
                                 #+clasp     "impl-clasp"
                                 #+cmu       "impl-cmucl"
                                 #+ecl       "impl-ecl"
                                 #+lispworks "impl-lispworks"
                                 #+sbcl      "impl-sbcl"
-                                #-(or allegro ccl clasp cmu ecl lispworks sbcl)
+                                #-(or abcl allegro ccl clasp cmu ecl lispworks sbcl)
                                   #.(error "static-vectors does not support this Common Lisp implementation!"))
                (:file "constructor" :depends-on ("pkgdcl" "constantp" "initialize" "impl"))
                (:file "cffi-type-translator" :depends-on ("pkgdcl" "impl")))


### PR DESCRIPTION
INCOMPLETE: (but more plausible.)  Part of upcoming abcl-1.6.2 release; available from <https://github.com/armedbear/abcl/pull/190> but that is a bit of work. Making a CI test to show what is currently failing.  Works better than nothing in the current state.

1. Does not work with anything other than 8 bit bytes.

Needs EXT:MAKE-BYTEBUFFER-BYTE-VECTOR available from
<https://github.com/easye/abcl/tree/easye/incomplete/bytebuffer-20200520a>.

Hack 'n slash towards something that compiles while sketching out
interfaces needed.  Most of what we need should be available in
<https://github.com/cffi/cffi/blob/master/src/cffi-abcl.lisp>,
especially around the MAKE-SHAREABLE-VECTOR interface.