### PR TITLE
Abcl/easye 20200601a

### DIFF
--- a/src/impl-abcl.lisp
+++ b/src/impl-abcl.lisp
@@ -5,12 +5,10 @@
 
 (in-package :static-vectors)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (unless
-      (fboundp (uiop:find-symbol* :make-niobuffer-vector :ext nil))
-    (error "For allocating memory via malloc(), ABCL needs an
+#-nio
+(error "For allocating memory via malloc(), ABCL needs an
 implementation of EXT:MAKE-NIOBUFFER-VECTOR, available in
-abcl-1.6.2-dev and the upcoming abcl-1.7.0.")))
+abcl-1.6.2-dev and the upcoming abcl-1.7.0.")
 
 (declaim (inline fill-foreign-memory))
 (defun fill-foreign-memory (pointer length value)
@@ -49,7 +47,7 @@ abcl-1.6.2-dev and the upcoming abcl-1.7.0.")))
            (bytebuffer
              (#"getByteBuffer" heap-pointer 0 bytes))
            (static-vector
-             (ext:make-niobuffer-vector bytebuffer :element-type element-type)))
+             (make-array :element-type element-type :nio-buffer bytebuffer)))
       (setf (gethash static-vector *static-vector-pointer*)
             heap-pointer)
       (values

--- a/src/impl-abcl.lisp
+++ b/src/impl-abcl.lisp
@@ -5,6 +5,13 @@
 
 (in-package :static-vectors)
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (unless
+      (fboundp (uiop:find-symbol* :make-niobuffer-vector :ext nil))
+    (error "For allocating memory via malloc(), ABCL needs an
+implementation of EXT:MAKE-NIOBUFFER-VECTOR, available in
+abcl-1.6.2-dev and the upcoming abcl-1.7.0.")))
+
 (declaim (inline fill-foreign-memory))
 (defun fill-foreign-memory (pointer length value)
   (foreign-funcall "memset" :pointer pointer :int value size-t length :pointer)
@@ -22,17 +29,27 @@
 
 (declaim (inline %allocate-static-vector))
 (defun %allocate-static-vector (length element-type)
-  (flet ((size-of (element-type)
-           ;; assume 8-bit bytes
-           1))
+  (let* ((type
+          (first element-type))
+         (bits-per-byte
+           (second element-type))
+         (bytes-per-element  ;; ehh, not going to work well for element type not of size 8, 16, or 32
+           (ceiling bits-per-byte 8)))
+    (unless (subtypep element-type
+                      '(or (unsigned-byte 8) (unsigned-byte 16) (unsigned-byte 32)))
+      (signal 'type-error :datum element-type
+                          :expected-type '(or
+                                           (unsigned-byte 8)
+                                           (unsigned-byte 16)
+                                           (unsigned-byte 32))))
     (let* ((bytes
-             (* length (size-of element-type)))
+             (* length bytes-per-element))
            (heap-pointer
              (jss:new "com.sun.jna.Memory" bytes))
            (bytebuffer
              (#"getByteBuffer" heap-pointer 0 bytes))
            (static-vector
-             (ext:make-bytebuffer-byte-vector bytebuffer)))
+             (ext:make-niobuffer-vector bytebuffer :element-type element-type)))
       (setf (gethash static-vector *static-vector-pointer*)
             heap-pointer)
       (values


### PR DESCRIPTION
Figured out a stable interface for the upcoming abcl-1.7.0

This "should" be the only merge I need to get STATIC-VECTORS to work no matter what bugs have in abcl-1.7.0. 

The presence of an ABCL implementation is now conditionalized on the presence of `:nio` in `CL:*FEATURES*.