### PR TITLE
Avoid modifying &rest lists

### DIFF
--- a/src/impl-abcl.lisp
+++ b/src/impl-abcl.lisp
@@ -85,10 +85,11 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(let ((,var (make-static-vector ,length ,@args
-                                     :element-type ,real-element-type)))
-       (declare (type ,type-spec ,var))
-       (unwind-protect
-            (locally ,@body)
-         (when ,var (free-static-vector ,var))))))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(let ((,var (make-static-vector ,length ,@args
+                                       :element-type ,real-element-type)))
+         (declare (type ,type-spec ,var))
+         (unwind-protect
+              (locally ,@body)
+           (when ,var (free-static-vector ,var)))))))

--- a/src/impl-allegro.lisp
+++ b/src/impl-allegro.lisp
@@ -44,10 +44,11 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(let ((,var (make-static-vector ,length ,@args
-                                     :element-type ,real-element-type)))
-       (declare (type ,type-spec ,var))
-       (unwind-protect
-            (locally ,@body)
-         (when ,var (free-static-vector ,var))))))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(let ((,var (make-static-vector ,length ,@args
+                                       :element-type ,real-element-type)))
+         (declare (type ,type-spec ,var))
+         (unwind-protect
+              (locally ,@body)
+           (when ,var (free-static-vector ,var)))))))

--- a/src/impl-clasp.lisp
+++ b/src/impl-clasp.lisp
@@ -49,10 +49,11 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(let ((,var (make-static-vector ,length ,@args
-                                     :element-type ,real-element-type)))
-       (declare (type ,type-spec ,var))
-       (unwind-protect
-            (locally ,@body)
-         (when ,var (free-static-vector ,var))))))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(let ((,var (make-static-vector ,length ,@args
+                                       :element-type ,real-element-type)))
+         (declare (type ,type-spec ,var))
+         (unwind-protect
+              (locally ,@body)
+           (when ,var (free-static-vector ,var)))))))

--- a/src/impl-clozure.lisp
+++ b/src/impl-clozure.lisp
@@ -46,10 +46,11 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(let ((,var (make-static-vector ,length ,@args
-                                     :element-type ,real-element-type)))
-       (declare (type ,type-spec ,var))
-       (unwind-protect
-            (locally ,@body)
-         (when ,var (free-static-vector ,var))))))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(let ((,var (make-static-vector ,length ,@args
+                                       :element-type ,real-element-type)))
+         (declare (type ,type-spec ,var))
+         (unwind-protect
+              (locally ,@body)
+           (when ,var (free-static-vector ,var)))))))

--- a/src/impl-cmucl.lisp
+++ b/src/impl-cmucl.lisp
@@ -44,8 +44,9 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(let ((,var (make-static-vector ,length ,@args
-                                     :element-type ,real-element-type)))
-       (declare (type ,type-spec ,var))
-       ,@body)))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(let ((,var (make-static-vector ,length ,@args
+                                       :element-type ,real-element-type)))
+         (declare (type ,type-spec ,var))
+         ,@body))))

--- a/src/impl-ecl.lisp
+++ b/src/impl-ecl.lisp
@@ -51,8 +51,9 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(let ((,var (make-static-vector ,length ,@args
-                                     :element-type ,real-element-type)))
-       (declare (type ,type-spec ,var))
-       ,@body)))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(let ((,var (make-static-vector ,length ,@args
+                                       :element-type ,real-element-type)))
+         (declare (type ,type-spec ,var))
+         ,@body))))

--- a/src/impl-lispworks.lisp
+++ b/src/impl-lispworks.lisp
@@ -45,8 +45,9 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(let ((,var (make-static-vector ,length ,@args
-                                     :element-type ,real-element-type)))
-       (declare (type ,type-spec ,var))
-       ,@body)))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(let ((,var (make-static-vector ,length ,@args
+                                       :element-type ,real-element-type)))
+         (declare (type ,type-spec ,var))
+         ,@body))))

--- a/src/impl-sbcl.lisp
+++ b/src/impl-sbcl.lisp
@@ -91,11 +91,12 @@ within its dynamic extent. The vector is freed upon exit."
   (declare (ignorable element-type initial-contents initial-element))
   (multiple-value-bind (real-element-type length type-spec)
       (canonicalize-args env element-type length)
-    (remf args :element-type)
-    `(sb-sys:without-interrupts
-       (let ((,var (make-static-vector ,length ,@args
-                                       :element-type ,real-element-type)))
-         (declare (type ,type-spec ,var))
-         (unwind-protect
-              (sb-sys:with-local-interrupts ,@body)
-           (when ,var (free-static-vector ,var)))))))
+    (let ((args (copy-list args)))
+      (remf args :element-type)
+      `(sb-sys:without-interrupts
+         (let ((,var (make-static-vector ,length ,@args
+                                         :element-type ,real-element-type)))
+           (declare (type ,type-spec ,var))
+           (unwind-protect
+                (sb-sys:with-local-interrupts ,@body)
+             (when ,var (free-static-vector ,var))))))))


### PR DESCRIPTION
Operator `remf` is destructive, and should not be used on `&rest` lists.