### PR TITLE
Fix for system-area-ub8-fill having been removed from SBCL

### DIFF
--- a/src/impl-sbcl.lisp
+++ b/src/impl-sbcl.lisp
@@ -9,7 +9,7 @@
 (defun fill-foreign-memory (pointer length value)
   "Fill LENGTH octets in foreign memory area POINTER with VALUE."
   (declare (sb-ext:muffle-conditions sb-ext:compiler-note))
-  (sb-kernel:system-area-ub8-fill value pointer 0 length)
+  (sb-kernel:ub8-bash-fill value pointer 0 length)
   pointer)
 
 (declaim (inline replace-foreign-memory))


### PR DESCRIPTION
The `system-area-` functions were removed in https://github.com/sbcl/sbcl/commit/74f31e021ebedebc2bd44db601b70e710651a2e8